### PR TITLE
Fix | v1 - Deprecate Invalid Page Property

### DIFF
--- a/src/Paginator.php
+++ b/src/Paginator.php
@@ -33,8 +33,15 @@ abstract class Paginator implements Iterator, Countable
 
     /**
      * Internal Marker For The Current Page
+     *
+     * @deprecated Use $currentPage instead
      */
     protected int $page = 1;
+
+    /**
+     * Denotes the current page
+     */
+    protected int $currentPage = 0;
 
     /**
      * When using async this is the total number of pages
@@ -165,6 +172,7 @@ abstract class Paginator implements Iterator, Countable
     public function next(): void
     {
         $this->page++;
+        $this->currentPage++;
     }
 
     /**
@@ -172,7 +180,7 @@ abstract class Paginator implements Iterator, Countable
      */
     public function key(): int
     {
-        return $this->page - 1;
+        return $this->currentPage;
     }
 
     /**
@@ -180,7 +188,7 @@ abstract class Paginator implements Iterator, Countable
      */
     public function valid(): bool
     {
-        if (isset($this->maxPages) && $this->page > $this->maxPages) {
+        if (isset($this->maxPages) && ($this->currentPage + 1) > $this->maxPages) {
             return false;
         }
 
@@ -189,7 +197,7 @@ abstract class Paginator implements Iterator, Countable
         }
 
         if ($this->isAsyncPaginationEnabled()) {
-            return $this->page <= $this->totalPages ??= $this->getTotalPages($this->currentResponse);
+            return ($this->currentPage + 1) <= $this->totalPages ??= $this->getTotalPages($this->currentResponse);
         }
 
         return $this->isLastPage($this->currentResponse) === false;
@@ -201,6 +209,7 @@ abstract class Paginator implements Iterator, Countable
     public function rewind(): void
     {
         $this->page = 1;
+        $this->currentPage = 0;
         $this->currentResponse = null;
         $this->totalResults = 0;
         $this->totalPages = null;
@@ -305,10 +314,20 @@ abstract class Paginator implements Iterator, Countable
 
     /**
      * Get page
+     *
+     * @deprecated Use currentPage() instead
      */
     public function getPage(): int
     {
         return $this->page;
+    }
+
+    /**
+     * Get the current page
+     */
+    public function getCurrentPage(): int
+    {
+        return $this->currentPage;
     }
 
     /**


### PR DESCRIPTION
This PR introduces a new property to the abstract `Paginator` class: `$this->currentPage`. This property should be used as a replacement for the `$this->page` property especially when used inside of the `isLastPage` method. 

I have deprecated the old `page` property and `getPage` method because they would often be one figure higher than they should be. The reason why is with the order of how iterators work in PHP.

1. Rewind is called
2. Valid is called
3. Current + Key is called
4. Next is called
5. Go to step 1 again

The old `page` property started at 1 on rewind so what happened was:

1. Rewind is called - `$this->page = 1`
2. Valid is called - _No response yet so `isLastPage` is not called_
3. Current + Key is called - _Get first page_
4. Next is called - `$this->page = 2`
5. Valid is called - **This is the issue - you would expect $this->page to be 1 but it's actually 2**

The new `currentPage` property is now being used internally in the code which starts at zero instead of one and all tests pass.