### PR TITLE
Add support for DTO from response

### DIFF
--- a/tests/Feature/DtoTest.php
+++ b/tests/Feature/DtoTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\LazyCollection;
+use Saloon\PaginationPlugin\Tests\Fixtures\Connectors\PagedConnector;
+use Saloon\PaginationPlugin\Tests\Fixtures\Data\Superhero;
+use Saloon\PaginationPlugin\Tests\Fixtures\Requests\DtoPagedRequest;
+
+test('you can iterate through the DTOs of a paginated resource', function () {
+    $connector = new PagedConnector;
+    $request = new DtoPagedRequest();
+    $paginator = $connector->paginate($request);
+
+    $superheroes = [];
+
+    foreach ($paginator->dtos() as $dto) {
+        $superheroes[] = $dto;
+    }
+
+    expect($superheroes)
+        ->toContainOnlyInstancesOf(Superhero::class)
+        ->toHaveCount(20);
+});
+
+test('you can iterate through the DTOs of a paginated resource using a lazy collection', function () {
+    $connector = new PagedConnector;
+    $request = new DtoPagedRequest();
+    $paginator = $connector->paginate($request);
+
+    $superheroes = $paginator->collectDtos();
+
+    expect($superheroes)
+        ->toBeInstanceOf(LazyCollection::class)
+        ->toContainOnlyInstancesOf(Superhero::class)
+        ->toHaveCount(20);
+});

--- a/tests/Fixtures/Requests/DtoPagedRequest.php
+++ b/tests/Fixtures/Requests/DtoPagedRequest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Saloon\PaginationPlugin\Tests\Fixtures\Requests;
+
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Http\Response;
+use Saloon\PaginationPlugin\Contracts\Paginatable;
+use Saloon\PaginationPlugin\Tests\Fixtures\Data\Superhero;
+
+class DtoPagedRequest extends Request implements Paginatable
+{
+    protected Method $method = Method::GET;
+
+    /**
+     * Define the endpoint for the request.
+     */
+    public function resolveEndpoint(): string
+    {
+        return '/superheroes/per-page';
+    }
+
+    public function createDtoFromResponse(Response $response): mixed
+    {
+        $items = $response->json()['data'];
+
+        return array_map(function ($item) {
+            return new Superhero(
+                id: $item['id'],
+                superhero: $item['superhero'],
+                publisher: $item['publisher'],
+                alter_ego: $item['alter_ego'],
+                first_appearance: $item['first_appearance'],
+                characters: $item['characters'],
+            );
+        }, $items);
+    }
+}


### PR DESCRIPTION
Discussed in saloonphp/saloon#399 and saloonphp/saloon#191.

The PR in its current state adds proof of concept support for generating DTOs from paginated responses.

# This approach

This is the simplest approach I could think of. The DTOs are generated from the `createDtoFromResponse` method in the `Request` class. Instead of returning a single DTO, you now parse the request into an array of DTOs. This is not apparent from any type signature—if anything, `createDtoFromResponse` being singular could be confusing.

Upsides:

* Adds almost no extra code or requirements
* Reuses functionality already present
* Adds no additional indirection

Downsides:

* Not apparent that `createDtoFromResponse`'s should return an array
* _Requires_ documentation to be followed
* Does not use the connector's `$itemsKey` if set, as the user is fully responsible for parsing the response, regardless of what the paginator is already doing
* Always parses entire responses at a time


# Possible alternative:

Rather than reusing the `Request`'s `createDtoFromResponse` we could create an interface like `CreatesDtosFromPaginatedResponses` with a method like `createDtoFromItem`. This method would have a single item as its argument, which comes directly from the `->items()` call on the request.

Upsides:

* Respects and reuses the way the paginator handles the response, including supporting optional settings like `$itemsKey`
* The user only has to parse any item into a DTO
* Using an interface communicates what is expected of the user, making it easier to implement

Downsides:

* Adds an additional layer of indirection
* Leaves `createsDtoFromResponse` around, while it is incompatible with this approach