### PR TITLE
Add support for DTO from response using an interface

### DIFF
--- a/src/Contracts/CreatesDtosFromPaginatedResponseItems.php
+++ b/src/Contracts/CreatesDtosFromPaginatedResponseItems.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Saloon\PaginationPlugin\Contracts;
+
+interface CreatesDtosFromPaginatedResponseItems
+{
+    /**
+     * Create DTOs from the paginated response items.
+     *
+     * @param array<array-key, mixed> $items
+     */
+    public function createDtoFromPaginatedResponseItem(array $items): object;
+}

--- a/src/Paginator.php
+++ b/src/Paginator.php
@@ -9,7 +9,7 @@ use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Support\LazyCollection;
 use InvalidArgumentException;
 use Iterator;
-use RuntimeException;
+use LogicException;
 use Saloon\Helpers\Helpers;
 use Saloon\Http\Connector;
 use Saloon\Http\Request;
@@ -279,7 +279,7 @@ abstract class Paginator implements Iterator, Countable
     public function dtos(): iterable
     {
         if (! $this->request instanceof CreatesDtosFromPaginatedResponseItems) {
-            throw new RuntimeException('The request must implement the `' . CreatesDtosFromPaginatedResponseItems::class . '` interface to be used on paginators.');
+            throw new LogicException('The request must implement the ' . CreatesDtosFromPaginatedResponseItems::class . ' interface to be used on paginators.');
         }
 
         foreach ($this->items() as $item) {

--- a/tests/Feature/DtoTest.php
+++ b/tests/Feature/DtoTest.php
@@ -3,12 +3,14 @@
 declare(strict_types=1);
 
 use Illuminate\Support\LazyCollection;
+use Saloon\PaginationPlugin\Contracts\CreatesDtosFromPaginatedResponseItems;
 use Saloon\PaginationPlugin\Tests\Fixtures\Connectors\PagedConnector;
 use Saloon\PaginationPlugin\Tests\Fixtures\Data\Superhero;
 use Saloon\PaginationPlugin\Tests\Fixtures\Requests\DtoPagedRequest;
+use Saloon\PaginationPlugin\Tests\Fixtures\Requests\SuperheroPagedRequest;
 
 test('you can iterate through the DTOs of a paginated resource', function () {
-    $connector = new PagedConnector;
+    $connector = new PagedConnector();
     $request = new DtoPagedRequest();
     $paginator = $connector->paginate($request);
 
@@ -24,7 +26,7 @@ test('you can iterate through the DTOs of a paginated resource', function () {
 });
 
 test('you can iterate through the DTOs of a paginated resource using a lazy collection', function () {
-    $connector = new PagedConnector;
+    $connector = new PagedConnector();
     $request = new DtoPagedRequest();
     $paginator = $connector->paginate($request);
 
@@ -35,3 +37,14 @@ test('you can iterate through the DTOs of a paginated resource using a lazy coll
         ->toContainOnlyInstancesOf(Superhero::class)
         ->toHaveCount(20);
 });
+
+test('throws an error when trying to iterate through the DTOs of a paginated resource without implementing the required interface', function () {
+    $connector = new PagedConnector();
+    $request = new SuperheroPagedRequest();
+    $paginator = $connector->paginate($request);
+
+    foreach ($paginator->dtos() as $ignored) {}
+})->throws(
+    LogicException::class,
+    'The request must implement the ' . CreatesDtosFromPaginatedResponseItems::class . ' interface to be used on paginators.'
+);

--- a/tests/Feature/DtoTest.php
+++ b/tests/Feature/DtoTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\LazyCollection;
+use Saloon\PaginationPlugin\Tests\Fixtures\Connectors\PagedConnector;
+use Saloon\PaginationPlugin\Tests\Fixtures\Data\Superhero;
+use Saloon\PaginationPlugin\Tests\Fixtures\Requests\DtoPagedRequest;
+
+test('you can iterate through the DTOs of a paginated resource', function () {
+    $connector = new PagedConnector;
+    $request = new DtoPagedRequest();
+    $paginator = $connector->paginate($request);
+
+    $superheroes = [];
+
+    foreach ($paginator->dtos() as $dto) {
+        $superheroes[] = $dto;
+    }
+
+    expect($superheroes)
+        ->toContainOnlyInstancesOf(Superhero::class)
+        ->toHaveCount(20);
+});
+
+test('you can iterate through the DTOs of a paginated resource using a lazy collection', function () {
+    $connector = new PagedConnector;
+    $request = new DtoPagedRequest();
+    $paginator = $connector->paginate($request);
+
+    $superheroes = $paginator->collectDtos();
+
+    expect($superheroes)
+        ->toBeInstanceOf(LazyCollection::class)
+        ->toContainOnlyInstancesOf(Superhero::class)
+        ->toHaveCount(20);
+});

--- a/tests/Fixtures/Requests/DtoPagedRequest.php
+++ b/tests/Fixtures/Requests/DtoPagedRequest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Saloon\PaginationPlugin\Tests\Fixtures\Requests;
+
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Http\Response;
+use Saloon\PaginationPlugin\Contracts\Paginatable;
+use Saloon\PaginationPlugin\Tests\Fixtures\Data\Superhero;
+
+class DtoPagedRequest extends Request implements Paginatable
+{
+    protected Method $method = Method::GET;
+
+    /**
+     * Define the endpoint for the request.
+     */
+    public function resolveEndpoint(): string
+    {
+        return '/superheroes/per-page';
+    }
+
+    public function createDtoFromResponse(Response $response): mixed
+    {
+        $items = $response->json()['data'];
+
+        return array_map(function ($item) {
+            return new Superhero(
+                id: $item['id'],
+                superhero: $item['superhero'],
+                publisher: $item['publisher'],
+                alter_ego: $item['alter_ego'],
+                first_appearance: $item['first_appearance'],
+                characters: $item['characters'],
+            );
+        }, $items);
+    }
+}

--- a/tests/Fixtures/Requests/DtoPagedRequest.php
+++ b/tests/Fixtures/Requests/DtoPagedRequest.php
@@ -6,11 +6,11 @@ namespace Saloon\PaginationPlugin\Tests\Fixtures\Requests;
 
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
-use Saloon\Http\Response;
+use Saloon\PaginationPlugin\Contracts\CreatesDtosFromPaginatedResponseItems;
 use Saloon\PaginationPlugin\Contracts\Paginatable;
 use Saloon\PaginationPlugin\Tests\Fixtures\Data\Superhero;
 
-class DtoPagedRequest extends Request implements Paginatable
+class DtoPagedRequest extends Request implements Paginatable, CreatesDtosFromPaginatedResponseItems
 {
     protected Method $method = Method::GET;
 
@@ -22,19 +22,15 @@ class DtoPagedRequest extends Request implements Paginatable
         return '/superheroes/per-page';
     }
 
-    public function createDtoFromResponse(Response $response): mixed
+    public function createDtoFromPaginatedResponseItem(array $items): object
     {
-        $items = $response->json()['data'];
-
-        return array_map(function ($item) {
-            return new Superhero(
-                id: $item['id'],
-                superhero: $item['superhero'],
-                publisher: $item['publisher'],
-                alter_ego: $item['alter_ego'],
-                first_appearance: $item['first_appearance'],
-                characters: $item['characters'],
-            );
-        }, $items);
+        return new Superhero(
+            id: $items['id'],
+            superhero: $items['superhero'],
+            publisher: $items['publisher'],
+            alter_ego: $items['alter_ego'],
+            first_appearance: $items['first_appearance'],
+            characters: $items['characters'],
+        );
     }
 }


### PR DESCRIPTION
Discussed in saloonphp/saloon#399 and saloonphp/saloon#191.

This PR support for generating DTOs from paginated responses.
