### PR TITLE
Update the return typehints for the fluent methods on the Paginator.

### DIFF
--- a/src/Paginator.php
+++ b/src/Paginator.php
@@ -291,7 +291,7 @@ abstract class Paginator implements Iterator, Countable
     /**
      * Set the maximum number of pages the paginator will iterate over
      */
-    public function setMaxPages(?int $maxPages): Paginator
+    public function setMaxPages(?int $maxPages): static
     {
         $this->maxPages = $maxPages;
 
@@ -301,7 +301,7 @@ abstract class Paginator implements Iterator, Countable
     /**
      * Set the per-page limit on the response
      */
-    public function setPerPageLimit(?int $perPageLimit): Paginator
+    public function setPerPageLimit(?int $perPageLimit): static
     {
         $this->perPageLimit = $perPageLimit;
 


### PR DESCRIPTION
This PR updates the return typehints for two of the fluent methods on the Paginator. The `setMaxPages()` and `setPerPageLimit()` methods were defined to return `Paginator` instances, but this has been updated to use the `static` keyword. This improves intellisense in IDEs.

For example, if you have the following method chain (connector is using a `PagedPaginator`):

```
$this
    ->connector
    ->paginate(new MyPagedRequest())
    ->setPerPageLimit(10)
    ->pool();
```

In this example, intellisense will complain that the `pool()` method doesn't exist. This is because the `setPerPageLimit()` is defined to return a `Paginator` instance, and that does not have the `pool()` method defined. However, the method actually returns a `PagedPaginator`, which does have the `pool()` method, and will work correctly. By updating the return type to `static`, intellisense will be able to resolve the correct returned instance type and see that the `pool()` method is valid.

As a note, the `setStartPage()` fluent method already correctly uses the `static` return typehint, so this is not a new thing for this class.