### PR TITLE
Fix | Reset body checksums on rewind to fix false infinite-loop

### DIFF
--- a/src/Paginator.php
+++ b/src/Paginator.php
@@ -212,6 +212,7 @@ abstract class Paginator implements Iterator, Countable
      */
     public function rewind(): void
     {
+        $this->lastFiveBodyChecksums = [];
         $this->currentPage = max(0, $this->startPage - 1);
         $this->page = $this->startPage;
         $this->currentResponse = null;

--- a/tests/Feature/CollectTest.php
+++ b/tests/Feature/CollectTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 use Saloon\Http\Response;
 use Illuminate\Support\Collection;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
 use Saloon\PaginationPlugin\Tests\Fixtures\Connectors\PagedConnector;
 use Saloon\PaginationPlugin\Tests\Fixtures\Requests\SuperheroPagedRequest;
 
@@ -28,4 +30,39 @@ test('can collect through paginated responses and not items', function () {
     expect(toIds($collection[3]->json('data')))->toEqual([16, 17, 18, 19, 20]);
 
     expect($paginator->getTotalResults())->toEqual(20);
+});
+
+/**
+ * @see https://github.com/saloonphp/saloon/issues/464
+ */
+test('multiple collect calls on same LazyCollection do not trigger infinite loop detection', function () {
+    $singlePageResponse = [
+        'data' => [['id' => 1], ['id' => 2]],
+        'next_page_url' => null,
+    ];
+
+    $connector = new PagedConnector;
+    $connector->withMockClient(new MockClient([
+        MockResponse::make($singlePageResponse),
+        MockResponse::make($singlePageResponse),
+        MockResponse::make($singlePageResponse),
+        MockResponse::make($singlePageResponse),
+        MockResponse::make($singlePageResponse),
+        MockResponse::make($singlePageResponse),
+    ]));
+
+    $request = new SuperheroPagedRequest;
+    $lazyCollection = $connector->paginate($request)->collect();
+
+    $first = $lazyCollection->collect();
+    expect($first)->toBeInstanceOf(Collection::class);
+    expect($first->pluck('id')->all())->toBe([1, 2]);
+
+    $lazyCollection->collect();
+    $lazyCollection->collect();
+    $lazyCollection->collect();
+    $lazyCollection->collect();
+
+    $again = $lazyCollection->collect();
+    expect($again->pluck('id')->all())->toBe([1, 2]);
 });


### PR DESCRIPTION
Fixes https://github.com/saloonphp/saloon/issues/464

Calling `collect()` multiple times on the same paginated LazyCollection could incorrectly trigger infinite-loop detection. The paginator’s `lastFiveBodyChecksums` was not cleared on `rewind()`, so a second (or later) collect run saw repeated body checksums and treated them as an infinite loop.

The solution I'm proposing is to clear `lastFiveBodyChecksums` in `Paginator::rewind()` so each iteration starts with a fresh checksum history. Multiple `collect()` calls on the same LazyCollection now complete without false positives.